### PR TITLE
Change version of supported GNOME Shell 40.0 to 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
     "shell-version": [
         "3.36",
         "3.38",
-        "40.0"
+        "40"
     ],
     "uuid": "airpods-battery-status@ju.wtf",
     "version": "1",


### PR DESCRIPTION
This extension is supposed to work every GNOME 40.x release, unless some internal things are dramatically changed, which is not going to happen as we hope :)

Right now the current stable GNOME version is not supported (40.1).