### PR TITLE
Bump the extension support for 44.x gnome shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
     "name": "Airpods Battery status",
     "description": "Show Airpods battery level in top bar\n\n/!\\ Needs AirStatus to work: https://github.com/delphiki/AirStatus",
     "shell-version": [
-        "43"
+        "43",
+        "44"
     ],
     "uuid": "airpods-battery-status@ju.wtf",
     "version": "8",


### PR DESCRIPTION
This PR adds support for Gnome Shell `v44.x` versions.

I've been able to run it on my Manjaro Gnome 44.1 system without any apparent issues.

![image](https://github.com/delphiki/gnome-airpods-battery-status/assets/54952031/5ca97edc-3f96-4beb-a842-370a8e09a001)


![image](https://github.com/delphiki/gnome-airpods-battery-status/assets/54952031/02a487ba-48ed-477a-af6c-0b6010c6402a)

Closes #10 